### PR TITLE
dockerize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ edition = "2021"
 uuid = {version ="1.5.0", features = ["v4"]}
 log = "0.4"
 env_logger = "0.10"
+
+[[bin]]
+name = "microircd"
+path = "src/main.rs"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Start from a Rust base image
+FROM rust:1.66 as builder
+
+# Set the current working directory inside the container
+WORKDIR /usr/src/microircd
+
+# Copy over your manifest
+COPY Cargo.toml .
+
+# Copy your source tree
+COPY src ./src
+
+# This build step will cache your dependencies
+RUN cargo build --release
+RUN rm src/*.rs
+
+# Our second stage, that only gets the built binary
+FROM debian:buster-slim
+COPY --from=builder /usr/src/microircd/target/release/microircd /usr/local/bin/microircd
+
+# Run the binary.
+CMD ["microircd"]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,39 @@ carbo build --release
 
 This will produce an executable in the `target/release` directory.
 
+## Docker
+
+### Building the Docker Image
+
+To build a Docker image for microircd, you can use the provided Dockerfile. Here's how you can build the Docker image:
+
+```bash
+docker build -t microircd .
+```
+This command builds a Docker image using the Dockerfile in the current directory and tags the image as microircd.
+
+### Running the Docker Image
+After you've built the Docker image, you can run it with the following command:
+
+```bash
+docker run -it --rm microircd
+```
+
+This command builds a Docker image using the Dockerfile in the current directory and tags the image as microircd.
+
+### Running the Docker Image
+After you've built the Docker image, you can run it with the following command:
+
+This command runs the microircd Docker image. The -it option allows you to interact with the container via your terminal, and the --rm option automatically removes the container when it exits.
+
+If your application requires specific ports to be open, you can use the -p option to map ports from your host to the Docker container. For example, if your application listens on port 8080, you can map this port to port 8080 on your host like this:
+
+```bash
+docker run -it --rm -p 6667:6667 microircd
+```
+
+You can add this section to your README.md file to provide instructions on how to build and run your Docker image.
+
 ## Contributing
 Contributions to microircd are welcome! Please submit issues and pull requests through GitHub.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
     env_logger::init();
 
     // TODO: parameterize the address
-    let server = Server::new("127.0.0.1:6667");
+    let server = Server::new("0.0.0.0:6667");
     info!("starting server on {}", server.address());
     if let Err(e) = server.run() {
         error!("Failed to start server: {}", e);


### PR DESCRIPTION
This pull request introduces changes to Dockerize the microircd application and update the Cargo.toml file.

Changes include:

* Dockerfile: A new Dockerfile has been added to the project. This Dockerfile defines a multi-stage build process that first builds the application using a Rust base image, and then creates a lightweight final image based on debian:buster-slim. The built application is copied from the build stage to the final image.

* Cargo.toml: The Cargo.toml file has been updated to include a new [[bin]] section. This section specifies that the microircd binary should be built from the src/main.rs file.

These changes will make it easier to build and distribute the microircd application. Users can now build a Docker image of the application with a single command, and the updated Cargo.toml file ensures that the correct binary is built.

Please review these changes and let me know if you have any questions or concerns.

